### PR TITLE
#853 New F# ClientSide

### DIFF
--- a/src/compiler/WebSharper.Compiler.FSharp/CodeReader.fs
+++ b/src/compiler/WebSharper.Compiler.FSharp/CodeReader.fs
@@ -1155,6 +1155,8 @@ let scanExpression (env: Environment) (containingMethodName: string) (expr: FSha
                                 }
                             let argNames = [ for (v, id, _) in env.FreeVars -> v.LogicalName ]
                             let f = Lambda([ for (_, id, _) in env.FreeVars -> id ], e)
+                            // emptying FreeVars so that env can be reused for reading multiple quotation arguments
+                            env.FreeVars.Clear()
                             quotations.Add(pos, qm, argNames, f) 
                         )
                     )

--- a/src/sitelets/WebSharper.Sitelets/Content.fs
+++ b/src/sitelets/WebSharper.Sitelets/Content.fs
@@ -63,6 +63,7 @@ module Content =
 
     let writeResources (ctx: Web.Context) (controls: seq<#IRequiresResources>) (tw: Core.Resources.RenderLocation -> UI.HtmlTextWriter) =
         // Resolve resources for the set of types and this assembly
+        // Some controls may depend on Requires called first and Encode second, do not break this
         let resources =
             let nodeSet =
                 controls

--- a/src/sitelets/WebSharper.Web/Control.fs
+++ b/src/sitelets/WebSharper.Web/Control.fs
@@ -25,7 +25,6 @@ open WebSharper.Core
 
 module M = WebSharper.Core.Metadata
 module R = WebSharper.Core.AST.Reflection
-//module P = WebSharper.Core.JavaScript.Packager
 
 /// A server-side control that adds a runtime dependency on a given resource.
 type Require (t: System.Type, [<System.ParamArray>] parameters: obj[]) =
@@ -107,212 +106,6 @@ type Control() =
 open WebSharper.JavaScript
 open Microsoft.FSharp.Quotations
 open Microsoft.FSharp.Quotations.Patterns
-
-/// Implements a web control based on a quotation-wrapped top-level body.
-/// Use the function ClientSide to create an InlineControl.
-
-type private FSV = Reflection.FSharpValue
-
-[<CompiledName "FSharpInlineControl">]
-type InlineControl<'T when 'T :> IControlBody>(getLocation: unit -> string, bodyAndReqs) =
-    inherit Control()
-
-    [<System.NonSerialized>]
-    let getLocation = getLocation
-
-    [<System.NonSerialized>]
-    let bodyAndReqs = bodyAndReqs
-
-    static let ctrlReq = M.TypeNode (R.ReadTypeDefinition typeof<InlineControl<IControlBody>>)
-
-    let args = fst bodyAndReqs
-    let mutable funcName = [||]
-
-    new (elt: Expr<'T>) =
-
-        let getLocation() =
-            let (|Val|_|) e : 't option =
-                match e with
-                | Quotations.Patterns.Value(:? 't as v,_) -> Some v
-                | _ -> None
-            let l =
-                elt.CustomAttributes |> Seq.tryPick (function
-                    | NewTuple [ Val "DebugRange";
-                                 NewTuple [ Val (file: string)
-                                            Val (startLine: int)
-                                            Val (startCol: int)
-                                            Val (endLine: int)
-                                            Val (endCol: int) ] ] ->
-                        Some (sprintf "%s: %i.%i-%i.%i" file startLine startCol endLine endCol)
-                    | _ -> None)
-            defaultArg l "(no location)"
-
-        let bodyAndReqs =
-            let declType, meth, args, fReqs, subs =
-                let elt =
-                    match elt :> Expr with
-                    | Coerce (e, _) -> e
-                    | e -> e
-                let rec get subs expr =
-                    match expr with
-                    | PropertyGet(None, p, args) ->
-                        let m = p.GetGetMethod(true)
-                        let dt = R.ReadTypeDefinition p.DeclaringType
-                        let meth = R.ReadMethod m
-                        dt, meth, args, [M.MethodNode (dt, meth)], subs
-                    | Call(None, m, args) ->
-                        let dt = R.ReadTypeDefinition m.DeclaringType
-                        let meth = R.ReadMethod m
-                        dt, meth, args, [M.MethodNode (dt, meth)], subs
-                    | Let(var, value, body) ->
-                        get (subs |> Map.add var value) body
-                    | e -> failwithf "Wrong format for InlineControl at %s: expected global value or function access, got: %A" (getLocation()) e
-                get Map.empty elt
-            let args, argReqs =
-                args
-                |> List.mapi (fun i value ->
-                    let rec get expr =
-                        match expr with
-                        | Value (v, t) ->
-                            let v = match v with null -> WebSharper.Core.Json.Internal.MakeTypedNull t | _ -> v
-                            v, M.TypeNode (R.ReadTypeDefinition t)
-                        | TupleGet(v, i) ->
-                            let v, n = get v
-                            FSV.GetTupleField(v, i), n
-                        | Var v when subs.ContainsKey v ->
-                            get subs.[v]   
-                        | _ -> failwithf "Wrong format for InlineControl at %s: argument #%i is not a literal or a local variable" (getLocation()) (i+1)
-                    get value
-                )
-                |> List.unzip
-            let args = Array.ofList args
-            let reqs = ctrlReq :: fReqs @ argReqs
-            args, (declType, meth, reqs)
-        new InlineControl<'T> (getLocation, bodyAndReqs)
-
-    [<JavaScript>]
-    override this.Body =
-        let f = Array.fold (?) JS.Window funcName
-        As<Function>(f).ApplyUnsafe(null, args) :?> _
-
-    interface IRequiresResources with
-        member this.Encode(meta, json) =
-            if funcName.Length = 0 then
-                let declType, meth, reqs = snd bodyAndReqs
-                let fail() =
-                    failwithf "Error in InlineControl at %s: Couldn't find translation of method %s.%s. The method or type should have JavaScript attribute or a proxy, and the assembly needs to be compiled with WsFsc.exe" 
-                        (getLocation()) declType.Value.FullName meth.Value.MethodName
-                match meta.Classes.TryFind declType with
-                | None -> fail()
-                | Some cls ->
-                    match cls.Methods.TryFind meth with
-                    | Some (M.Static a, _, _) ->
-                        funcName <- Array.ofList (List.rev a.Value)
-                    | Some _ ->
-                        failwithf "Error in InlineControl at %s: Method %s.%s must be static and not inlined"
-                            (getLocation()) declType.Value.FullName meth.Value.MethodName
-                    | None -> fail()
-            [this.ID, json.GetEncoder(this.GetType()).Encode this]
-
-        member this.Requires(_) =
-            let _, _, reqs = snd bodyAndReqs 
-            this.GetBodyNode() :: reqs |> Seq.ofList
-
-open System
-open System.Reflection
-open System.Linq.Expressions
-
-// TODO: test in arguments: needs .NET 4.5
-// open System.Runtime.CompilerServices
-//[<CallerFilePath; Optional>] sourceFilePath 
-//[<CallerLineNumber; Optional>] sourceLineNumber
-[<CompiledName "InlineControl">]
-type CSharpInlineControl(elt: System.Linq.Expressions.Expression<Func<IControlBody>>) =
-    inherit Control()
-
-    [<System.NonSerialized>]
-    let elt = elt
-
-    static let ctrlReq = M.TypeNode (R.ReadTypeDefinition typeof<InlineControl<IControlBody>>)
-
-    [<System.NonSerialized>]
-    let bodyAndReqs =
-        let reduce (e: Expression) = if e.CanReduce then e.Reduce() else e
-        let declType, meth, args, fReqs =
-            match reduce elt.Body with
-            | :? MemberExpression as e ->
-                match e.Member with
-                | :? PropertyInfo as p ->
-                    let m = p.GetGetMethod(true)
-                    let dt = R.ReadTypeDefinition p.DeclaringType
-                    let meth = R.ReadMethod m
-                    dt, meth, [], [M.MethodNode (dt, meth)]
-                | _ -> failwith "member must be a property"
-            | :? MethodCallExpression as e -> 
-                let m = e.Method
-                let dt = R.ReadTypeDefinition m.DeclaringType
-                let meth = R.ReadMethod m
-                dt, meth, e.Arguments |> List.ofSeq, [M.MethodNode (dt, meth)]
-            | e -> failwithf "Wrong format for InlineControl: expected global value or function access, got: %A"  e
-        let args, argReqs =
-            args
-            |> List.mapi (fun i a -> 
-                let rec get needType (a: Expression) =
-                    match reduce a with
-                    | :? ConstantExpression as e ->
-                        let v = match e.Value with null -> WebSharper.Core.Json.Internal.MakeTypedNull e.Type | _ -> e.Value
-                        v, if needType then M.TypeNode (R.ReadTypeDefinition e.Type) else M.EntryPointNode
-                    | :? MemberExpression as e ->
-                        let o = 
-                            match e.Expression with
-                            | null -> null
-                            | ee -> fst (get false ee)
-                        match e.Member with
-                        | :? FieldInfo as f ->
-                            f.GetValue(o), if needType then M.TypeNode (R.ReadTypeDefinition f.FieldType) else M.EntryPointNode
-                        | :? PropertyInfo as p ->
-                            if p.GetIndexParameters().Length > 0 then
-                                failwithf "Wrong format for InlineControl in argument #%i, indexed property not allowed" (i+1)
-                            p.GetValue(o, null), if needType then M.TypeNode (R.ReadTypeDefinition p.PropertyType) else M.EntryPointNode
-                        | m -> failwithf "Wrong format for InlineControl in argument #%i, member access not allowed: %s" (i+1) (m.GetType().Name)
-                    | a -> failwithf "Wrong format for InlineControl in argument #%i, expression type: %s" (i+1) (a.GetType().Name)
-                get true a
-            )
-            |> List.unzip
-        let args = Array.ofList args
-        let reqs = ctrlReq :: fReqs @ argReqs
-        args, (declType, meth, reqs)
-
-    let args = fst bodyAndReqs
-    let mutable funcName = [||]
-
-    [<JavaScript>]
-    override this.Body =
-        let f = Array.fold (?) JS.Window funcName
-        As<Function>(f).ApplyUnsafe(null, args) :?> _
-
-    interface IRequiresResources with
-        member this.Encode(meta, json) =
-            if funcName.Length = 0 then
-                let declType, meth, reqs = snd bodyAndReqs
-                let fail() =
-                    failwithf "Error in InlineControl: Couldn't find translation of method %s.%s. The method or type should have JavaScript attribute or a proxy, and the project file needs to include Zafir.CSharp.targets" 
-                        declType.Value.FullName meth.Value.MethodName
-                match meta.Classes.TryFind declType with
-                | None -> fail()
-                | Some cls ->
-                    match cls.Methods.TryFind meth with
-                    | Some (M.Static a, _, _) ->
-                        funcName <- Array.ofList (List.rev a.Value)
-                    | Some _ -> 
-                        failwithf "Error in InlineControl: Method %s.%s must be static and not inlined"
-                            declType.Value.FullName meth.Value.MethodName
-                    | None -> fail()
-            [this.ID, json.GetEncoder(this.GetType()).Encode this]
-
-        member this.Requires(_) =
-            let _, _, reqs = snd bodyAndReqs 
-            this.GetBodyNode() :: reqs |> Seq.ofList
 
 module ClientSideInternals =
 
@@ -420,8 +213,6 @@ module ClientSideInternals =
             findArgs (Set.add v1.Name env) setArg q1
             findArgs (Set.add v2.Name env) setArg q2
         | _ -> ()
-
-    let emptyArg = obj()
     
     let internal compileClientSide (meta: M.Info) (reqs: list<M.Node>) (q: Expr) : (obj[] * _) =
         let rec compile (reqs: list<M.Node>) (q: Expr) =
@@ -439,34 +230,177 @@ module ClientSideInternals =
                     | false, _ -> failwithf "Error in ClientSide: Couldn't find JavaScript address for method %s.%s" declType.Value.FullName meth.Value.MethodName
                     | true, c ->
                         let argIndices = Map (argNames |> List.mapi (fun i x -> x, i))
-                        let args = Array.create argNames.Length emptyArg
+                        let args = Array.create argNames.Length null
                         let reqs = ref (M.MethodNode (declType, meth) :: M.TypeNode declType :: reqs)
                         let setArg (name: string) (value: obj) =
                             let i = argIndices.[name]
-                            if args.[i] = emptyArg then
+                            if isNull args.[i] then
                                 args.[i] <-
                                     match value with
                                     | :? Expr as q ->
-                                        failwith "Error in ClientSide: Spliced expressions are not allowed"
-                                        //let x, reqs' = compile !reqs q
-                                        //reqs := reqs'
-                                        //x
+                                        failwith "Error in ClientSide: Spliced expressions are not allowed in InlineControl"
                                     | value ->
                                         let typ = value.GetType ()
                                         reqs := M.TypeNode (WebSharper.Core.AST.Reflection.ReadTypeDefinition typ) :: !reqs
                                         value
                         findArgs Set.empty setArg q
-                        match args |> Array.tryFindIndex ((=) emptyArg) with
-                        | Some u ->
-                             failwithf "Error in ClientSide: captured argument failed to be filled: %s in %A" argNames.[u] q
-                        | _ -> ()
-                        let addr =
-                            match c.Methods.TryGetValue meth with
-                            | true, (M.CompiledMember.Static x, _, _) -> x.Value
-                            | _ -> failwithf "Error in ClientSide: Couldn't find JavaScript address for method %s.%s" declType.Value.FullName meth.Value.MethodName
                         args, !reqs
             | None -> failwithf "Failed to find location of quotation: %A" q
         compile reqs q 
+
+open ClientSideInternals
+
+/// Implements a web control based on a quotation-wrapped top-level body.
+/// Use the function ClientSide or ctx.ClientSide to create an InlineControl.
+[<CompiledName "FSharpInlineControl">]
+type InlineControl<'T when 'T :> IControlBody>(elt: Expr<'T>) =
+    inherit Control()
+
+    [<System.NonSerialized>]
+    let elt = elt
+
+    let mutable args = [||]
+    let mutable funcName = [||]
+
+    [<JavaScript>]
+    override this.Body =
+        let f = Array.fold (?) JS.Window funcName
+        As<Function>(f).ApplyUnsafe(null, args) :?> _
+
+    interface IRequiresResources with
+        member this.Requires(meta) =
+            let declType, meth, reqs =
+                match getLocation elt with
+                | None -> failwith "Failed to find location of quotation"
+                | Some p ->
+                    match meta.Quotations.TryGetValue p with
+                    | true, (ty, m, _) ->
+                        let argVals, deps = compileClientSide meta [] elt
+                        args <- argVals
+                        ty, m, deps
+                    | false, _ ->
+                        let all =
+                            meta.Quotations.Keys
+                            |> Seq.map (sprintf "    %O")
+                            |> String.concat "\n"
+                        failwithf "Failed to find compiled quotation at position %O\nExisting ones:\n%O" p all
+
+            // set funcName
+            let fail() =
+                failwithf "Error in InlineControl at %s: Couldn't find translation of method %s.%s. The method or type should have JavaScript attribute or a proxy, and the assembly needs to be compiled with WsFsc.exe" 
+                    (getLocation' elt) declType.Value.FullName meth.Value.MethodName
+            match meta.Classes.TryFind declType with
+            | None -> fail()
+            | Some cls ->
+                match cls.Methods.TryFind meth with
+                | Some (M.Static a, _, _) ->
+                    funcName <- Array.ofList (List.rev a.Value)
+                | Some _ ->
+                    failwithf "Error in InlineControl at %s: Method %s.%s must be static and not inlined"
+                        (getLocation' elt) declType.Value.FullName meth.Value.MethodName
+                | None -> fail()
+
+            this.GetBodyNode() :: reqs |> Seq.ofList
+
+        member this.Encode(meta, json) =
+            [this.ID, json.GetEncoder(this.GetType()).Encode this]
+
+
+open System
+open System.Reflection
+open System.Linq.Expressions
+
+// TODO: test in arguments: needs .NET 4.5
+// open System.Runtime.CompilerServices
+//[<CallerFilePath; Optional>] sourceFilePath 
+//[<CallerLineNumber; Optional>] sourceLineNumber
+[<CompiledName "InlineControl">]
+type CSharpInlineControl(elt: System.Linq.Expressions.Expression<Func<IControlBody>>) =
+    inherit Control()
+
+    [<System.NonSerialized>]
+    let elt = elt
+
+    static let ctrlReq = M.TypeNode (R.ReadTypeDefinition typeof<InlineControl<IControlBody>>)
+
+    [<System.NonSerialized>]
+    let bodyAndReqs =
+        let reduce (e: Expression) = if e.CanReduce then e.Reduce() else e
+        let declType, meth, args, fReqs =
+            match reduce elt.Body with
+            | :? MemberExpression as e ->
+                match e.Member with
+                | :? PropertyInfo as p ->
+                    let m = p.GetGetMethod(true)
+                    let dt = R.ReadTypeDefinition p.DeclaringType
+                    let meth = R.ReadMethod m
+                    dt, meth, [], [M.MethodNode (dt, meth)]
+                | _ -> failwith "member must be a property"
+            | :? MethodCallExpression as e -> 
+                let m = e.Method
+                let dt = R.ReadTypeDefinition m.DeclaringType
+                let meth = R.ReadMethod m
+                dt, meth, e.Arguments |> List.ofSeq, [M.MethodNode (dt, meth)]
+            | e -> failwithf "Wrong format for InlineControl: expected global value or function access, got: %A"  e
+        let args, argReqs =
+            args
+            |> List.mapi (fun i a -> 
+                let rec get needType (a: Expression) =
+                    match reduce a with
+                    | :? ConstantExpression as e ->
+                        let v = match e.Value with null -> WebSharper.Core.Json.Internal.MakeTypedNull e.Type | _ -> e.Value
+                        v, if needType then M.TypeNode (R.ReadTypeDefinition e.Type) else M.EntryPointNode
+                    | :? MemberExpression as e ->
+                        let o = 
+                            match e.Expression with
+                            | null -> null
+                            | ee -> fst (get false ee)
+                        match e.Member with
+                        | :? FieldInfo as f ->
+                            f.GetValue(o), if needType then M.TypeNode (R.ReadTypeDefinition f.FieldType) else M.EntryPointNode
+                        | :? PropertyInfo as p ->
+                            if p.GetIndexParameters().Length > 0 then
+                                failwithf "Wrong format for InlineControl in argument #%i, indexed property not allowed" (i+1)
+                            p.GetValue(o, null), if needType then M.TypeNode (R.ReadTypeDefinition p.PropertyType) else M.EntryPointNode
+                        | m -> failwithf "Wrong format for InlineControl in argument #%i, member access not allowed: %s" (i+1) (m.GetType().Name)
+                    | a -> failwithf "Wrong format for InlineControl in argument #%i, expression type: %s" (i+1) (a.GetType().Name)
+                get true a
+            )
+            |> List.unzip
+        let args = Array.ofList args
+        let reqs = ctrlReq :: fReqs @ argReqs
+        args, (declType, meth, reqs)
+
+    let args = fst bodyAndReqs
+    let mutable funcName = [||]
+
+    [<JavaScript>]
+    override this.Body =
+        let f = Array.fold (?) JS.Window funcName
+        As<Function>(f).ApplyUnsafe(null, args) :?> _
+
+    interface IRequiresResources with
+        member this.Encode(meta, json) =
+            if funcName.Length = 0 then
+                let declType, meth, reqs = snd bodyAndReqs
+                let fail() =
+                    failwithf "Error in InlineControl: Couldn't find translation of method %s.%s. The method or type should have JavaScript attribute or a proxy, and the project file needs to include Zafir.CSharp.targets" 
+                        declType.Value.FullName meth.Value.MethodName
+                match meta.Classes.TryFind declType with
+                | None -> fail()
+                | Some cls ->
+                    match cls.Methods.TryFind meth with
+                    | Some (M.Static a, _, _) ->
+                        funcName <- Array.ofList (List.rev a.Value)
+                    | Some _ -> 
+                        failwithf "Error in InlineControl: Method %s.%s must be static and not inlined"
+                            declType.Value.FullName meth.Value.MethodName
+                    | None -> fail()
+            [this.ID, json.GetEncoder(this.GetType()).Encode this]
+
+        member this.Requires(_) =
+            let _, _, reqs = snd bodyAndReqs 
+            this.GetBodyNode() :: reqs |> Seq.ofList
 
 namespace WebSharper
 
@@ -474,61 +408,10 @@ namespace WebSharper
 module WebExtensions =
 
     open Microsoft.FSharp.Quotations
-    open Microsoft.FSharp.Quotations.Patterns
-    open WebSharper.Core
     open WebSharper.Web
-
-    open ClientSideInternals
 
     /// Embed the given client-side control body in a server-side control.
     /// The client-side control body must be an implicit or explicit quotation expression.
+    /// It can capture local variables, of the same types which are serializable by WebSharper as RPC results.
     let ClientSide ([<JavaScript; ReflectedDefinition>] e: Expr<#IControlBody>) =
-        match getLocation e with
-        | None -> failwith "Failed to find location of quotation"
-        | Some p ->
-            match Shared.Metadata.Quotations.TryGetValue p with
-            | true, (ty, m, _) ->
-                let args, deps = compileClientSide Shared.Metadata [] e
-                new InlineControl<_>((fun () -> ""), (args, (ty, m, deps)))
-            | false, _ ->
-                let all =
-                    Shared.Metadata.Quotations.Keys
-                    |> Seq.map (sprintf "    %O")
-                    |> String.concat "\n"
-                failwithf "Failed to find compiled quotation at position %O\nExisting ones:\n%O" p all
-
-    type WebSharper.Web.Context with
-        member this.ClientSide([<WebSharper.JavaScript>] elt: Expr<#IControlBody>) =
-            let (|Val|_|) e : 't option =
-                match e with
-                | Quotations.Patterns.Value(:? 't as v,_) -> Some v
-                | _ -> None
-            let pos =
-                elt.CustomAttributes |> Seq.tryPick (function
-                    | NewTuple [ Val "DebugRange";
-                                 NewTuple [ Val (file: string)
-                                            Val (startLine: int)
-                                            Val (startCol: int)
-                                            Val (endLine: int)
-                                            Val (endCol: int) ] ] ->
-                        ({
-                            FileName = System.IO.Path.GetFileName(file)
-                            Start = (startLine, startCol)
-                            End = (endLine, endCol)
-                        } : WebSharper.Core.AST.SourcePos)
-                        |> Some
-                    | _ -> None)
-            match pos with
-            | None -> failwith "Failed to find location of quotation"
-            | Some p ->
-                match this.Metadata.Quotations.TryGetValue p with
-                | true, (ty, m, _) ->
-                    let deps = this.Dependencies.GetDependencies [WebSharper.Core.Metadata.MethodNode(ty, m)]
-                    new InlineControl<_>((fun () -> ""), ([||], (ty, m, deps)))
-                | false, _ ->
-                    let all =
-                        this.Metadata.Quotations.Keys
-                        |> Seq.map (sprintf "    %O")
-                        |> String.concat "\n"
-                    failwithf "Failed to find compiled quotation at position %O\nExisting ones:\n%O" p all
-            :> WebSharper.Web.Control
+        new InlineControl<_>(e)

--- a/tests/WebSharper.CSharp.Sitelets.Tests/Tests.cs
+++ b/tests/WebSharper.CSharp.Sitelets.Tests/Tests.cs
@@ -5,6 +5,7 @@ using WebSharper.Sitelets;
 using Elt = WebSharper.Sitelets.Tests.Server.Elt;
 using Attr = WebSharper.Sitelets.Tests.Server.Attr;
 using Text = WebSharper.Sitelets.Tests.Server.Text;
+using C = WebSharper.Sitelets.Tests.Client;
 
 namespace WebSharper.CSharp.Sitelets.Tests
 {
@@ -13,28 +14,28 @@ namespace WebSharper.CSharp.Sitelets.Tests
     {
         [JavaScript]
         public override IControlBody Body =>
-            new WebSharper.Sitelets.Tests.Client.Elt("div", "Hello from a web control class!");
+            C.Elt("div", C.Text("Hello from a web control class!"));
     }
 
     public class SiteletTest
     {
         [JavaScript]
-        public static WebSharper.Sitelets.Tests.Client.Elt SayHello()
+        public static C.Node SayHello()
         {
             Console.WriteLine("Hello world from System.Console!");
             JavaScript.Console.Log("Hello world from WebSharper.JavaScript.Console!");
-            return new WebSharper.Sitelets.Tests.Client.Elt("div", "Hello from an inline control!");
+            return C.Elt("div", C.Text("Hello from an inline control!"));
         }
 
         [JavaScript]
-        public static WebSharper.Sitelets.Tests.Client.Elt SayHello(string msg)
+        public static C.Node SayHello(string msg)
         {
-            return new WebSharper.Sitelets.Tests.Client.Elt("div", $"Hello from an inline control with message: {msg}!");
+            return C.Elt("div", C.Text($"Hello from an inline control with message: {msg}!"));
         }
 
         [JavaScript]
-        public static WebSharper.Sitelets.Tests.Client.Elt Hello =>
-            new WebSharper.Sitelets.Tests.Client.Elt("div", "Hello from an inline control calling a static property!");
+        public static C.Node Hello =>
+            C.Elt("div", C.Text("Hello from an inline control calling a static property!"));
 
         public static Sitelet<object> Main =>
             new SiteletBuilder()

--- a/tests/WebSharper.Sitelets.Tests/SampleSite.fs
+++ b/tests/WebSharper.Sitelets.Tests/SampleSite.fs
@@ -215,9 +215,9 @@ module SampleSite =
                 [
                     Elt("h1", Text "Welcome to our site!")
                     "Let us know how we can contact you" => ctx.Link Action.Contact
-                    Elt("div", ctx.ClientSide <@ Client.Elt "b" [|Client.Text "It's working baby"|] @>)
+                    Elt("div", ClientSide <@ Client.Elt "b" [|Client.Text "It's working baby"|] @>)
                     Elt("div",
-                        ctx.ClientSide
+                        ClientSide
                             <@ Client.Elt "i" [|
                                 Client.Text "It "
                                 Client.Elt "b" [|Client.Text "really"|]

--- a/tests/WebSharper.Sitelets.Tests/SampleSite.fs
+++ b/tests/WebSharper.Sitelets.Tests/SampleSite.fs
@@ -20,19 +20,34 @@
 
 namespace WebSharper.Sitelets.Tests
 
+open System
 open WebSharper
 
 module Client =
     open WebSharper.JavaScript
 
     [<JavaScript>]
-    type Elt(name, text) =
-        let e = JS.Document.CreateElement(name)
-        do e.AppendChild(JS.Document.CreateTextNode(text)) |> ignore
+    type Node =
+        | Elt of string * Node[]
+        | Text of string
+
+        member this.ToNode() =
+            match this with
+            | Text t -> JS.Document.CreateTextNode(t) :> Dom.Node
+            | Elt (n, ch) ->
+                let e = JS.Document.CreateElement(n)
+                for ch in ch do e.AppendChild(ch.ToNode()) |> ignore
+                e :> Dom.Node
 
         interface IControlBody with
             member this.ReplaceInDom x =
-                x.ParentNode.ReplaceChild(e, x) |> ignore
+                x.ParentNode.ReplaceChild(this.ToNode(), x) |> ignore
+
+    [<JavaScript>]
+    let Elt n ([<ParamArray>] ch) = Node.Elt(n, ch)
+
+    [<JavaScript>]
+    let Text t = Node.Text(t)
 
     [<Sealed>]
     type SignupSequenceControl() =
@@ -40,7 +55,7 @@ module Client =
 
         [<JavaScript>]
         override this.Body =
-            Elt("div", "SIGNUP-SEQUENCE") :> _
+            Elt "div" [|Text "SIGNUP-SEQUENCE"|] :> _
 
     [<Sealed>]
     type LoginControl(link: string) =
@@ -48,11 +63,11 @@ module Client =
 
         [<JavaScript>]
         override this.Body =
-            Elt("div", "LOGIN: " + link) :> _
+            Elt "div" [|Text ("LOGIN: " + link)|] :> _
 
     [<JavaScript>]
     let Widget () =
-        Elt("button", "click me!")
+        Elt "button" [|Text "click me!"|]
 
 /// A mini server-side HTML language
 module Server =
@@ -200,6 +215,14 @@ module SampleSite =
                 [
                     Elt("h1", Text "Welcome to our site!")
                     "Let us know how we can contact you" => ctx.Link Action.Contact
+                    Elt("div", ctx.ClientSide <@ Client.Elt "b" [|Client.Text "It's working baby"|] @>)
+                    Elt("div",
+                        ctx.ClientSide
+                            <@ Client.Elt "i" [|
+                                Client.Text "It "
+                                Client.Elt "b" [|Client.Text "really"|]
+                                Client.Text " is!"
+                            |] @>)
                 ]
 
         /// A page to collect contact information.


### PR DESCRIPTION
F# ClientSide control switched to using compile-time support to handle arbitrary fixed quotations with captured local values.